### PR TITLE
setup postcss-nested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "moment": "^2.29.4",
         "next": "^13.5.4",
         "next-compose-plugins": "^2.2.1",
+        "postcss-nested": "^6.0.1",
         "postcss-preset-env": "^9.2.0",
         "react": "18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -2792,7 +2793,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -5561,6 +5561,24 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/postcss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.11"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
     "node_modules/postcss-nesting": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.0.1.tgz",
@@ -5827,7 +5845,6 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6768,8 +6785,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "moment": "^2.29.4",
     "next": "^13.5.4",
     "next-compose-plugins": "^2.2.1",
+    "postcss-nested": "^6.0.1",
     "postcss-preset-env": "^9.2.0",
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,6 +2,7 @@ module.exports = {
   plugins: {
     'postcss-flexbugs-fixes': {},
     'postcss-import': {},
+    'postcss-nested': {},
     'postcss-preset-env': {
       autoprefixer: {
         flexbox: 'no-2009',


### PR DESCRIPTION
1. Do nested CSS
```css
/* before */
.navbar {
  padding: 1rem;
}

.navbar__container {
  background: red;
}

/* after */
.navbar {
  padding: 1rem;

  &__container {
    background: red;
  }
}
```
2. `npm run postcss:watch`
3. Changes should apply correctly

Do note that you don't want to implement nesting hell, as a general rule don't nest deeper than 3 levels. You can even [setup stylelint nesting rule](https://stylelint.io/user-guide/rules/max-nesting-depth/) to enforce that.